### PR TITLE
fix: Bind orientation handler for correct this in event

### DIFF
--- a/public/js/core/geolocation.js
+++ b/public/js/core/geolocation.js
@@ -12,6 +12,7 @@ export default class Geolocation {
     this._hasHeadingMarker = false;
     this._lastAutomaticZoom = null;
     this._map = map;
+    this._onOrientationFound = this._onOrientationFound.bind(this);
   }
 
   /**


### PR DESCRIPTION
I noticed when testing that the orientation handler does not rotate the icon as expected, because the event handler is not bound to the Geolocation object:

```
Uncaught TypeError: this._rotateMarker is not a function
    at _onOrientationFound (geolocation.js:206)
```

This PR should fix it - I currently cannot convince the code to build on my machine, but have successfully used the new line at a breakpoint in the same location.